### PR TITLE
fix(sharemenu): corrigir cópia de link para usar URL atual da página

### DIFF
--- a/src/components/ui/sharemenu.tsx
+++ b/src/components/ui/sharemenu.tsx
@@ -29,6 +29,8 @@ export default function Sharemenu({ service }: ShareMenuProps) {
 
   const copyLink = async () => {
     try {
+      const url = window.location.href;
+
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(url);
         toast.success("✅ Link copiado para a área de transferência!");
@@ -41,7 +43,7 @@ export default function Sharemenu({ service }: ShareMenuProps) {
       }
     } catch (err) {
       console.error("Erro ao copiar link:", err);
-      const fallback = window.prompt("⚠️ Não foi possível copiar. Copie manualmente:", url);
+      const fallback = window.prompt("⚠️ Não foi possível copiar. Copie manualmente:", window.location.href);
       if (fallback !== null) {
         toast.error("Falha ao copiar automaticamente, use o link manual.");
       }


### PR DESCRIPTION
### Descrição
- Ajustado o método `copyLink` para utilizar `window.location.href`.
- Agora a função copia corretamente o link da página atual (ex: /services/2).
- Mantida a estrutura original com fallback via prompt e mensagens de toast.

### Testes
- Testado em /services/1 → copia corretamente.
- Testado em /services/2 → copia corretamente.
- Testado fallback sem suporte a clipboard → exibe prompt com link certo.

### Checklist
- [x] Código revisado
- [x] Testado em ambiente local
- [x] Mantida compatibilidade com fallback
